### PR TITLE
logging k8s API response body if an error occurred

### DIFF
--- a/src/main/scala/jp/co/septeni_original/k8sop/CreateJobOperatorFactory.scala
+++ b/src/main/scala/jp/co/septeni_original/k8sop/CreateJobOperatorFactory.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.Executors
 import com.typesafe.scalalogging.LazyLogging
 import io.digdag.spi._
 import io.digdag.util.BaseOperator
-import io.kubernetes.client.Configuration
+import io.kubernetes.client.{ApiException, Configuration}
 import io.kubernetes.client.models._
 import io.kubernetes.client.util.authenticators.GCPAuthenticator
 import io.kubernetes.client.util.{Config, KubeConfig, Yaml}
@@ -91,6 +91,10 @@ private[k8sop] class CreateJobOperator private[k8sop] (val _context: OperatorCon
       throw new RuntimeException("job failed.")
     }
   } catch {
+    case e: ApiException =>
+      logger.error(s"k8s API response: ${e.getResponseBody}", e)
+      throw new TaskExecutionException(e)
+
     case NonFatal(e) =>
       logger.error("unexpected error occurred.", e)
       throw new TaskExecutionException(e)


### PR DESCRIPTION
k8s API response body helps you when an error occurred.  This PR makes k8s_job enable to log the message. 

The added log looks like the following:

```
2018-09-28 14:19:07 +0900 [ERROR] (0046@[0:sample-workflow]+foo): k8s API response: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"ConfigMap \"invalid_metadata_name\" is invalid: metadata.name: Invalid value: \"bq-imp-1-twitter-p_romotedtweets\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')","reason":"Invalid","details":{"name":"invalid_metadata_name","kind":"ConfigMap","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"invalid_metadata_name\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')","field":"metadata.name"}]},"code":422}
```