### PR TITLE
Update Kubernetes Java Client to 4.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,10 +20,7 @@ libraryDependencies ++= Seq(
   "org.slf4j"                  % "slf4j-api"       % "1.7.25",
   "commons-io"                 % "commons-io"      % "2.5",
   "ch.qos.logback"             % "logback-classic" % "1.2.3" % Provided,
-  // 以下のPRがリリースされるまではYamlクラスが正常に動作しないので、maven cenralではなくjitpackから読む。
-  // https://github.com/kubernetes-client/java/pull/314
-  //  "io.kubernetes"              % "client-java"     % "2.0.0",
-  "com.github.kubernetes-client.java" % "client-java" % "9e23b710f1bf024ca691b3617cd20dc4dc2933e1",
+  "io.kubernetes"              % "client-java"     % "4.0.0",
   // provide by digdag-server or client.
   "io.digdag" % "digdag-spi"          % digdagVersion % Provided,
   "io.digdag" % "digdag-plugin-utils" % digdagVersion % Provided,

--- a/src/main/scala/jp/co/septeni_original/k8sop/ConfigMapClient.scala
+++ b/src/main/scala/jp/co/septeni_original/k8sop/ConfigMapClient.scala
@@ -38,7 +38,7 @@ class ConfigMapClient(val client: ApiClient)(implicit ec: ExecutionContext) exte
     val cmF = ols2cmls(objects).map { (cm: V1ConfigMap) =>
       logger.debug(s"ConfigMap create start. cm: $cm")
       FutureOps.retryWithRefresh {
-        val res = api.createNamespacedConfigMap(cm.getMetadata.getNamespace, cm, "false")
+        val res = api.createNamespacedConfigMap(cm.getMetadata.getNamespace, cm, false, "false", null)
         logger.debug(s"ConfigMap create complete.")
         res
       }
@@ -60,6 +60,7 @@ class ConfigMapClient(val client: ApiClient)(implicit ec: ExecutionContext) exte
                                            cm.getMetadata.getNamespace,
                                            deleteOption,
                                            "false",
+                                           null,
                                            null,
                                            null,
                                            null,

--- a/src/main/scala/jp/co/septeni_original/k8sop/JobClient.scala
+++ b/src/main/scala/jp/co/septeni_original/k8sop/JobClient.scala
@@ -25,7 +25,7 @@ class JobClient(val client: ApiClient)(implicit ec: ExecutionContext) extends La
       ols2jls(objects).map { j =>
         FutureOps.retryWithRefresh {
           logger.debug(s"Job create start. $j")
-          val res = api.createNamespacedJob(j.getMetadata.getNamespace, j, "false")
+          val res = api.createNamespacedJob(j.getMetadata.getNamespace, j, false, "false", null)
           logger.debug(s"Job create complete.")
           res
         }
@@ -70,6 +70,7 @@ class JobClient(val client: ApiClient)(implicit ec: ExecutionContext) extends La
                                      j.getMetadata.getNamespace,
                                      deleteOption,
                                      "false",
+                                     null,
                                      null,
                                      null,
                                      null,

--- a/src/main/scala/jp/co/septeni_original/k8sop/util/FileReader.scala
+++ b/src/main/scala/jp/co/septeni_original/k8sop/util/FileReader.scala
@@ -1,8 +1,8 @@
 package jp.co.septeni_original.k8sop.util
 
 import java.io.File
+import java.nio.charset.StandardCharsets
 
-import com.nimbusds.jose.util.StandardCharset
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FileUtils
 
@@ -21,7 +21,7 @@ object FileReader extends LazyLogging {
       .toList
       .filter(_.isFile)
       .map { f =>
-        (f.getName, FileUtils.readFileToString(f, StandardCharset.UTF_8))
+        (f.getName, FileUtils.readFileToString(f, StandardCharsets.UTF_8))
       }
       .toMap
   }


### PR DESCRIPTION
The k8s java-client 4.0.0 includes the following bug fix(ClassCastException).

* https://github.com/kubernetes-client/java/issues/460 